### PR TITLE
Add govulncheck step to Go builds

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -29,6 +29,11 @@ jobs:
         run: |
           go test ./...
 
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ${{ inputs.go-version }}
+
       - name: Check GoReleaser
         if: inputs.uses-goreleaser
         uses: goreleaser/goreleaser-action@v5.0.0

--- a/.github/workflows/go-with-releaser-image.yml
+++ b/.github/workflows/go-with-releaser-image.yml
@@ -38,6 +38,11 @@ jobs:
         run: |
           go test ./...
 
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ${{ inputs.go-version }}
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3.2.0
         with:

--- a/.github/workflows/go-with-releaser.yml
+++ b/.github/workflows/go-with-releaser.yml
@@ -31,6 +31,11 @@ jobs:
         run: |
           go test ./...
 
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ${{ inputs.go-version }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5.0.0
         with:


### PR DESCRIPTION
Drawing inspiration from https://github.com/tianon/gosu/blob/master/SECURITY.md, this adds a github actions step that runs
https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck