### PR TITLE
Revert "Add govulncheck step to Go builds"

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -29,11 +29,6 @@ jobs:
         run: |
           go test ./...
 
-      - id: govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          go-version-input: ${{ inputs.go-version }}
-
       - name: Check GoReleaser
         if: inputs.uses-goreleaser
         uses: goreleaser/goreleaser-action@v5.0.0

--- a/.github/workflows/go-with-releaser-image.yml
+++ b/.github/workflows/go-with-releaser-image.yml
@@ -38,11 +38,6 @@ jobs:
         run: |
           go test ./...
 
-      - id: govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          go-version-input: ${{ inputs.go-version }}
-
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3.2.0
         with:

--- a/.github/workflows/go-with-releaser.yml
+++ b/.github/workflows/go-with-releaser.yml
@@ -31,11 +31,6 @@ jobs:
         run: |
           go test ./...
 
-      - id: govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          go-version-input: ${{ inputs.go-version }}
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5.0.0
         with:


### PR DESCRIPTION
Reverts itzg/github-workflows#27

The github action seems to re-run its own set of checkout and setup-go which creates for a very noisy run:

https://github.com/itzg/mc-monitor/actions/runs/8578462515/job/23536614399

Will need to reconsider how to incorporate this. Perhaps it needs to be its own job rather than a step within the existing jobs.
