### PR TITLE
Add govulncheck job to Go builds

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -35,3 +35,11 @@ jobs:
         with:
           version: ${{ inputs.goreleaser-version }}
           args: build --clean --snapshot
+  govulncheck:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ${{ inputs.go-version }}

--- a/.github/workflows/go-with-releaser-image.yml
+++ b/.github/workflows/go-with-releaser-image.yml
@@ -58,3 +58,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCOOP_TAP_GITHUB_TOKEN: ${{ secrets.scoop-tap-github-token }}
+  govulncheck:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ${{ inputs.go-version }}

--- a/.github/workflows/go-with-releaser.yml
+++ b/.github/workflows/go-with-releaser.yml
@@ -39,3 +39,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCOOP_TAP_GITHUB_TOKEN: ${{ secrets.scoop-tap-github-token }}
+  govulncheck:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ${{ inputs.go-version }}


### PR DESCRIPTION
Drawing inspiration from https://github.com/tianon/gosu/blob/master/SECURITY.md, this adds a github actions job that runs https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck

Follow up to #27 