### PR TITLE
issues-notify: handle single quotes in title

### DIFF
--- a/.github/workflows/issues-notify-discord.yml
+++ b/.github/workflows/issues-notify-discord.yml
@@ -18,14 +18,15 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Overview
+        env:
+          ACTION: ${{ github.event.action }}
+          TITLE: ${{ github.event.issue.title }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
+          CHANGED_LABEL: ${{ github.event.label.name }}
+          URL: ${{ github.event.issue.html_url }}
+          REPO: ${{ github.event.repository.full_name }}
         run: |
-          ACTION='${{ github.event.action }}'
-          TITLE='${{ github.event.issue.title }}'
-          NUMBER='${{ github.event.issue.number }}'
-          LABELS="${{ join(github.event.issue.labels.*.name, ', ') }}"
-          CHANGED_LABEL='${{ github.event.label.name }}'
-          URL='${{ github.event.issue.html_url }}'
-          REPO='${{ github.event.repository.full_name }}'
           echo "issueTitleLink=[$TITLE (#$NUMBER)](<$URL>) in $REPO" >> $GITHUB_ENV
           echo "Issue action $ACTION for $TITLE ($NUMBER) with labels '$LABELS' and changed label '$CHANGED_LABEL'"
 


### PR DESCRIPTION
Otherwise, build error

```
Run ACTION='unlabeled'
  ACTION='unlabeled'
  TITLE='Can't set gamemode on 1.13.2'
  NUMBER='4119'
  LABELS="discussion"
  CHANGED_LABEL='bug'
  URL='https://github.com/itzg/docker-minecraft-server/issues/4119'
  REPO='itzg/docker-minecraft-server'
  echo "issueTitleLink=[$TITLE (#$NUMBER)](<$URL>) in $REPO" >> $GITHUB_ENV
  echo "Issue action $ACTION for $TITLE ($NUMBER) with labels '$LABELS' and changed label '$CHANGED_LABEL'"
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/02778c95-a0f5-42c5-979f-cf745e89103d.sh: line 9: unexpected EOF while looking for matching `''
Error: Process completed with exit code 2.
```

> Direct interpolation of GitHub context variables into shell scripts is unsafe as it can lead to syntax errors or command injection. The recommended solution is to map these variables to environment variables using the env key of the step.